### PR TITLE
Fix port & URL for API

### DIFF
--- a/src/EbulkSMS.php
+++ b/src/EbulkSMS.php
@@ -53,13 +53,13 @@ class EbulkSMS
      * SMS Endpoint
      * @var string
      */
-    protected $endpoint = "http://api.ebulksms.com:8080/sendsms.json";
+    protected $endpoint = "https://api.ebulksms.com/sendsms.json";
 
     /**
      * Balance Endpoint
      * @var string
      */
-    protected $balance_endpoint = "http://api.ebulksms.com:8080/balance/";
+    protected $balance_endpoint = "https://api.ebulksms.com/balance/";
 
     /**
      * If message should be flashed or sent


### PR DESCRIPTION
This fix addresses updates to the EbulkSMS API for deactivated port 8080.
Also, all API requests must now go through **HTTPS**.